### PR TITLE
Add CLAUDE.md and a validate skill for Claude Code sessions

### DIFF
--- a/.claude/skills/validate/SKILL.md
+++ b/.claude/skills/validate/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: validate
+description: Run the pre-commit validation checks for the Grant Aerona3 integration (Python syntax, strings.json/translations.json JSON validity and parity). Use before committing or opening a PR, since this repo has no CI or test suite.
+---
+
+Run these checks from the repo root and report pass/fail for each — don't stop at the first failure, run all of them and summarize:
+
+1. **Python syntax** — compile every module in the integration:
+   ```
+   python3 -m py_compile custom_components/grant_aerona3/*.py
+   ```
+   No output means success; a `SyntaxError` traceback points at the bad file/line.
+
+2. **JSON validity** — `strings.json` and `translations/en.json` must both parse:
+   ```
+   python3 -c "import json; json.load(open('custom_components/grant_aerona3/strings.json')); json.load(open('custom_components/grant_aerona3/translations/en.json')); print('OK')"
+   ```
+
+3. **Translations parity** — the two files must have identical keys (Home Assistant loads `translations/en.json` at runtime, not `strings.json`, so they silently drift if only one is edited):
+   ```
+   diff <(python3 -c "import json,sys; print(json.dumps(json.load(open('custom_components/grant_aerona3/strings.json')), sort_keys=True, indent=2))") \
+        <(python3 -c "import json,sys; print(json.dumps(json.load(open('custom_components/grant_aerona3/translations/en.json')), sort_keys=True, indent=2))")
+   ```
+   Any diff output means the two files have drifted apart — fix by copying the changed section across, not by picking one file arbitrarily (see the root [CLAUDE.md](../../../CLAUDE.md) for which file HA actually reads at runtime).
+
+If a register or hand-written entity was added or changed, also sanity-check the feature-gating conventions in the root `CLAUDE.md` were followed (register listed in the right `*_REGISTER_FEATURES` dict, unique_id suffix added to `FEATURE_UNIQUE_ID_SUFFIXES` if applicable) — this isn't machine-checkable, so review it by eye.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# Grant Aerona3 Home Assistant Integration
+
+Unofficial HACS integration for Grant Aerona3 air-source heat pumps, talking Modbus over serial/TCP. Solo-maintained, no CI — validation is manual (see `.claude/skills/validate`).
+
+## Feature-gating architecture
+
+Users only get entities for hardware they actually own (an unfiltered install creates 150+ entities). Don't add a new register or entity without wiring it into this system:
+
+- Feature keys live in `const.py`: `has_dhw_tank`, `has_buffer`, `has_ehs`, `has_cooling`, `zones` (`"single"`/`"dual"`, exposed internally as the pseudo-feature `zone2`). `DEFAULT_FEATURES` turns everything ON — this is required so existing config entries keep all their entities after an upgrade; don't change these defaults for backward-compat reasons even though a fresh UK install would prefer heating-only/no-DHW defaults (that's handled in the config flow, not here).
+- Register gating is data-driven: `INPUT_REGISTER_FEATURES`, `HOLDING_REGISTER_FEATURES`, `COIL_REGISTER_FEATURES` in `const.py` map register ID → tuple of required feature keys (AND semantics — e.g. Zone 2 cooling needs both `has_cooling` and `zone2`). A register absent from its map is core and always enabled/polled.
+- `features.py` holds the helpers: `get_feature(entry, key, default)` (options flow value wins over the original data), `enabled_features(entry)`, `register_enabled(features, feature_map, reg_id)`. The coordinator computes `self.features` once; platforms read features from the coordinator, not from the config entry directly.
+- **When adding a register**: decide its feature tuple in the relevant `*_REGISTER_FEATURES` dict in `const.py`.
+- **When adding a gated hand-written entity** (not register-driven, e.g. a switch built directly in `switch.py`): also add its unique_id suffix to `FEATURE_UNIQUE_ID_SUFFIXES` in `__init__.py`. `_remove_disabled_entities` uses that map to purge registry entries for disabled features on setup — miss it and the entity lingers as "unavailable" forever instead of disappearing.
+
+## Gotchas
+
+- `translations/en.json` must be kept as an exact copy of `strings.json`. Home Assistant loads `translations/` at runtime, not `strings.json` (that file is only for the HA developer-docs tooling) — editing one without the other silently desyncs the UI strings.
+- The coordinator only polls a hardcoded subset of coils (`critical_coils` in `coordinator.py`'s `_read_coil_registers`, currently coils 2, 3, 6, 7, 18) to avoid Modbus timeouts, but roughly 20 coil-backed switches exist in `switch.py`. Any switch outside that subset shows stale/last-known state rather than live state — this is a known gap, not a bug you're introducing if you touch nearby code.
+- `weather_compensation.py` and `weather_compensation_entities.py` are dead code — nothing imports `weather_compensation_entities`, and only it imports `weather_compensation`. The literal string `"weather_compensation"` appears elsewhere only as part of unrelated entity unique_ids/entity_ids, not as a wire-up. Don't assume these modules are reachable; either finish wiring them or remove them, don't build on top of them as-is.
+- `options_flow.py` was removed as dead code already — the options flow lives inside `config_flow.py`'s `OptionsFlowHandler`. Don't recreate a separate file for it.
+
+## Validation
+
+There's no test suite or CI. Before committing, run the `validate` skill (or manually: `python3 -m py_compile` on every file in `custom_components/grant_aerona3/`, plus a JSON load check on `strings.json` and `translations/en.json`).


### PR DESCRIPTION
Document the feature-gating architecture and its non-obvious gotchas (translations/en.json vs strings.json sync, the coordinator's limited coil polling, dead weather-compensation modules) so this knowledge survives across sessions and machines instead of living only in one session's local memory. Also add a project skill that packages the existing manual pre-commit validation routine (py_compile, JSON validity, strings/translations parity) since the repo has no CI.